### PR TITLE
Specify resolver in bindings usage instructions

### DIFF
--- a/docs/src/paradox/bindings/iconv.md
+++ b/docs/src/paradox/bindings/iconv.md
@@ -1,6 +1,15 @@
 # Iconv - Character set conversion
 
-To use this binding add the following dependency:
+To use this binding add the following resolver and the dependency:
+
+sbt
+:   @@snip [build.sbt](../resources/build.sbt) { #library_resolver }
+
+Maven
+:   @@snip [pom.xml](../resources/pom.xml) { #library_resolver }
+
+Gradle
+:   @@snip [build.gradle](../resources/build.gradle) { #library_resolver }
 
 @@dependency[sbt,Maven,Gradle] {
   group="org.scala-native.bindgen"

--- a/docs/src/paradox/bindings/iconv.md
+++ b/docs/src/paradox/bindings/iconv.md
@@ -3,13 +3,13 @@
 To use this binding add the following resolver and the dependency:
 
 sbt
-:   @@snip [build.sbt](../resources/build.sbt) { #library_resolver }
+:   @@snip [build.sbt](../resources/build.sbt)
 
 Maven
 :   @@snip [pom.xml](../resources/pom.xml) { #library_resolver }
 
 Gradle
-:   @@snip [build.gradle](../resources/build.gradle) { #library_resolver }
+:   @@snip [build.gradle](../resources/build.gradle)
 
 @@dependency[sbt,Maven,Gradle] {
   group="org.scala-native.bindgen"

--- a/docs/src/paradox/bindings/posix.md
+++ b/docs/src/paradox/bindings/posix.md
@@ -3,13 +3,13 @@
 An addition to Scala Native's [POSIX](http://www.scala-native.org/en/latest/lib/posixlib.html) bindings. To use one of the POSIX bindings you must add the resolver and the dependency:
 
 sbt
-:   @@snip [build.sbt](../resources/build.sbt) { #library_resolver }
+:   @@snip [build.sbt](../resources/build.sbt)
 
 Maven
 :   @@snip [pom.xml](../resources/pom.xml) { #library_resolver }
 
 Gradle
-:   @@snip [build.gradle](../resources/build.gradle) { #library_resolver }
+:   @@snip [build.gradle](../resources/build.gradle)
 
 
 @@dependency[sbt,Maven,Gradle] {

--- a/docs/src/paradox/bindings/posix.md
+++ b/docs/src/paradox/bindings/posix.md
@@ -1,6 +1,16 @@
 # POSIX
 
-An addition to Scala Native's [POSIX](http://www.scala-native.org/en/latest/lib/posixlib.html) bindings. To use one of the POSIX bindings you must add it as a dependency:
+An addition to Scala Native's [POSIX](http://www.scala-native.org/en/latest/lib/posixlib.html) bindings. To use one of the POSIX bindings you must add the resolver and the dependency:
+
+sbt
+:   @@snip [build.sbt](../resources/build.sbt) { #library_resolver }
+
+Maven
+:   @@snip [pom.xml](../resources/pom.xml) { #library_resolver }
+
+Gradle
+:   @@snip [build.gradle](../resources/build.gradle) { #library_resolver }
+
 
 @@dependency[sbt,Maven,Gradle] {
   group="org.scala-native.bindgen"

--- a/docs/src/paradox/bindings/utf8proc.md
+++ b/docs/src/paradox/bindings/utf8proc.md
@@ -2,7 +2,16 @@
 
 This binding for [`utf8proc.h`] provides Unicode normalization, case-folding, and other operations for strings in the UTF-8 encoding.
 
-To use it add the following dependency:
+To use it add the following resolver and the dependency:
+
+sbt
+:   @@snip [build.sbt](../resources/build.sbt) { #library_resolver }
+
+Maven
+:   @@snip [pom.xml](../resources/pom.xml) { #library_resolver }
+
+Gradle
+:   @@snip [build.gradle](../resources/build.gradle) { #library_resolver }
 
 @@dependency[sbt,Maven,Gradle] {
   group="org.scala-native.bindgen"

--- a/docs/src/paradox/bindings/utf8proc.md
+++ b/docs/src/paradox/bindings/utf8proc.md
@@ -5,13 +5,13 @@ This binding for [`utf8proc.h`] provides Unicode normalization, case-folding, an
 To use it add the following resolver and the dependency:
 
 sbt
-:   @@snip [build.sbt](../resources/build.sbt) { #library_resolver }
+:   @@snip [build.sbt](../resources/build.sbt)
 
 Maven
 :   @@snip [pom.xml](../resources/pom.xml) { #library_resolver }
 
 Gradle
-:   @@snip [build.gradle](../resources/build.gradle) { #library_resolver }
+:   @@snip [build.gradle](../resources/build.gradle)
 
 @@dependency[sbt,Maven,Gradle] {
   group="org.scala-native.bindgen"

--- a/docs/src/paradox/resources/build.gradle
+++ b/docs/src/paradox/resources/build.gradle
@@ -1,0 +1,7 @@
+// #library_resolver
+repositories {
+    maven {
+        url "https://dl.bintray.com/scala-native-bindgen/maven"
+    }
+}
+// #library_resolver

--- a/docs/src/paradox/resources/build.gradle
+++ b/docs/src/paradox/resources/build.gradle
@@ -1,7 +1,5 @@
-// #library_resolver
 repositories {
     maven {
         url "https://dl.bintray.com/scala-native-bindgen/maven"
     }
 }
-// #library_resolver

--- a/docs/src/paradox/resources/build.sbt
+++ b/docs/src/paradox/resources/build.sbt
@@ -1,3 +1,1 @@
-// #library_resolver
 resolvers += Resolver.bintrayRepo("scala-native-bindgen", "maven")
-// #library_resolver

--- a/docs/src/paradox/resources/build.sbt
+++ b/docs/src/paradox/resources/build.sbt
@@ -1,0 +1,3 @@
+// #library_resolver
+resolvers += Resolver.bintrayRepo("scala-native-bindgen", "maven")
+// #library_resolver

--- a/docs/src/paradox/resources/pom.xml
+++ b/docs/src/paradox/resources/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>maven-scala-test</artifactId>
+
+    <!-- #library_resolver -->
+    <repositories>
+        <repository>
+            <id>maven</id>
+            <url>http://dl.bintray.com/scala-native-bindgen/maven</url>
+        </repository>
+    </repositories>
+    <!-- #library_resolver -->
+
+</project>


### PR DESCRIPTION
Show how to specify url of bintray repo to use bindings.

 Instructions are still not valid because artifactId in instructions does not match real one.

For example artifactId for libiconv is `libiconv_native0.3` but docs say it's `libiconv`. I suppose we should change artifactId on bintray because it should not contain version and `_native` postfix is also strange.
@Jonas, I could not figure out how to change artifactId.

To do:
 - [ ] Show resolver and dependency in the same code snippet