### PR TITLE
Handle coursier download failures in scalafmt

### DIFF
--- a/scripts/scalafmt
+++ b/scripts/scalafmt
@@ -1,20 +1,23 @@
 #!/usr/bin/env bash
 
-# set -x
+# Bash strict mode
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
 
 HERE="`dirname $0`"
 VERSION="1.5.1"
 COURSIER="$HERE/.coursier"
 SCALAFMT="$HERE/.scalafmt-$VERSION"
 
-if [ ! -f $COURSIER ]; then
-  curl -L -o $COURSIER https://git.io/vgvpD
-  chmod +x $COURSIER
+if [ ! -x "$COURSIER" ]; then
+  curl -L -o "$COURSIER" "https://github.com/coursier/coursier/raw/v1.0.3/coursier"
+  chmod +x "$COURSIER"
 fi
 
-if [ ! -f $SCALAFMT ]; then
-  $COURSIER bootstrap com.geirsson:scalafmt-cli_2.11:$VERSION --main org.scalafmt.cli.Cli -o $SCALAFMT
-  chmod +x $SCALAFMT
+if [ ! -f "$SCALAFMT" ]; then
+  "$COURSIER" bootstrap com.geirsson:scalafmt-cli_2.11:$VERSION --main org.scalafmt.cli.Cli -o "$SCALAFMT"
+  chmod +x "$SCALAFMT"
 fi
 
-exit $($SCALAFMT "$@" >/dev/null)
+exec "$SCALAFMT" "$@" >/dev/null


### PR DESCRIPTION
Fail the scalafmt script if curl cannot download the coursier binary.
Also point directly to the latest stable coursier release instead of
the master as was the case for git.io link.