### PR TITLE
Fix #173: Reorganize bindings

### DIFF
--- a/bindings/iconv/src/main/scala/org/scalanative/bindings/iconv.scala
+++ b/bindings/iconv/src/main/scala/org/scalanative/bindings/iconv.scala
@@ -1,4 +1,4 @@
-package org.scalanative.bindgen.bindings.iconv
+package org.scalanative.bindings
 
 import scala.scalanative._
 import scala.scalanative.native._

--- a/bindings/iconv/src/test/scala/org/scalanative/bindings/tests/IconvSpec.scala
+++ b/bindings/iconv/src/test/scala/org/scalanative/bindings/tests/IconvSpec.scala
@@ -1,4 +1,4 @@
-package org.scalanative.bindgen.bindings.iconv.tests
+package org.scalanative.bindings.tests
 
 import org.scalatest.FunSpec
 
@@ -6,7 +6,7 @@ class IconvSpec extends FunSpec {
   describe("iconv") {
     it("should convert back and forth between UTF-8 and ISO-8859-1") {
       //#usage-example
-      import org.scalanative.bindgen.bindings.iconv.iconv._
+      import org.scalanative.bindings.iconv._
       import scala.scalanative.native._
       import java.nio.charset.Charset
 

--- a/bindings/posix/src/main/scala/org/scalanative/bindings/posix/fnmatch.scala
+++ b/bindings/posix/src/main/scala/org/scalanative/bindings/posix/fnmatch.scala
@@ -1,4 +1,4 @@
-package org.scalanative.bindgen.bindings.posix
+package org.scalanative.bindings.posix
 
 import scala.scalanative._
 import scala.scalanative.native._

--- a/bindings/posix/src/main/scala/org/scalanative/bindings/posix/regex.scala
+++ b/bindings/posix/src/main/scala/org/scalanative/bindings/posix/regex.scala
@@ -1,4 +1,4 @@
-package org.scalanative.bindgen.bindings.posix
+package org.scalanative.bindings.posix
 
 import scala.scalanative._
 import scala.scalanative.native._

--- a/bindings/posix/src/test/scala/org/scalanative/bindings/tests/FnmatchSpec.scala
+++ b/bindings/posix/src/test/scala/org/scalanative/bindings/tests/FnmatchSpec.scala
@@ -1,4 +1,4 @@
-package org.scalanative.bindgen.bindings.tests
+package org.scalanative.bindings.tests
 
 import org.scalatest.FunSpec
 
@@ -7,7 +7,7 @@ class FnmatchSpec extends FunSpec {
     it("should match patterns") {
       //#usage-example
       import scala.scalanative.native._
-      import org.scalanative.bindgen.bindings.posix.fnmatch._
+      import org.scalanative.bindings.posix.fnmatch._
 
       assert(fnmatch(c"*.md", c"README.md", 0) == 0)
       assert(fnmatch(c"*.[ch]", c"main.h", 0) == 0)

--- a/bindings/posix/src/test/scala/org/scalanative/bindings/tests/RegexSpec.scala
+++ b/bindings/posix/src/test/scala/org/scalanative/bindings/tests/RegexSpec.scala
@@ -1,4 +1,4 @@
-package org.scalanative.bindgen.bindings.tests
+package org.scalanative.bindings.tests
 
 import org.scalatest.FunSpec
 
@@ -7,7 +7,7 @@ class RegexSpec extends FunSpec {
     it("should match regular expressions") {
       //#usage-example
       import scala.scalanative.native._
-      import org.scalanative.bindgen.bindings.posix.regex._
+      import org.scalanative.bindings.posix.regex._
 
       val reg = stackalloc[regex_t]
 

--- a/bindings/utf8proc/src/main/scala/org/scalanative/bindings/utf8proc.scala
+++ b/bindings/utf8proc/src/main/scala/org/scalanative/bindings/utf8proc.scala
@@ -1,4 +1,4 @@
-package org.scalanative.bindgen.bindings.utf8proc
+package org.scalanative.bindings
 
 import scala.scalanative._
 import scala.scalanative.native._

--- a/bindings/utf8proc/src/test/scala/org/scalanative/bindings/tests/Utf8procSpec.scala
+++ b/bindings/utf8proc/src/test/scala/org/scalanative/bindings/tests/Utf8procSpec.scala
@@ -1,4 +1,4 @@
-package org.scalanative.bindgen.bindings.tests
+package org.scalanative.bindings.tests
 
 import org.scalatest.FunSpec
 
@@ -6,7 +6,7 @@ class Utf8procSpec extends FunSpec {
   describe("utf8proc") {
     it("should iterate UTF-8 and count character width") {
       //#usage-example
-      import org.scalanative.bindgen.bindings.utf8proc.utf8proc._
+      import org.scalanative.bindings.utf8proc._
       import scala.scalanative.native._
 
       val text    = c"Spørge"
@@ -32,7 +32,7 @@ class Utf8procSpec extends FunSpec {
     }
 
     it("utf8proc_tolower") {
-      import org.scalanative.bindgen.bindings.utf8proc.utf8proc._
+      import org.scalanative.bindings.utf8proc._
 
       val `Ø`  = 0x00D8
       val `ø`  = 0x00F8

--- a/docs/src/paradox/bindings/iconv.md
+++ b/docs/src/paradox/bindings/iconv.md
@@ -13,6 +13,6 @@ For sbt, you can use the following code:
 
 ## Example
 
-@@snip [iconv](../../../../bindings/iconv/src/test/scala/org/scalanative/bindgen/bindings/tests/IconvSpec.scala) { #usage-example }
+@@snip [iconv](../../../../bindings/iconv/src/test/scala/org/scalanative/bindings/tests/IconvSpec.scala) { #usage-example }
 
  [`iconv.h`]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/iconv.h.html

--- a/docs/src/paradox/bindings/posix.md
+++ b/docs/src/paradox/bindings/posix.md
@@ -20,8 +20,8 @@ Binding objects are available under the package name `
 
 Using `fnmatch.h`:
 
-@@snip [fnmatch](../../../../bindings/posix/src/test/scala/org/scalanative/bindgen/bindings/tests/FnmatchSpec.scala) { #usage-example }
+@@snip [fnmatch](../../../../bindings/posix/src/test/scala/org/scalanative/bindings/tests/FnmatchSpec.scala) { #usage-example }
 
 Using `regex.h`:
 
-@@snip [regex](../../../../bindings/posix/src/test/scala/org/scalanative/bindgen/bindings/tests/RegexSpec.scala) { #usage-example }
+@@snip [regex](../../../../bindings/posix/src/test/scala/org/scalanative/bindings/tests/RegexSpec.scala) { #usage-example }

--- a/docs/src/paradox/bindings/utf8proc.md
+++ b/docs/src/paradox/bindings/utf8proc.md
@@ -8,6 +8,6 @@ To use this binding add the following resolver and dependency:
 
 ## Example
 
-@@snip [iconv](../../../../bindings/utf8proc/src/test/scala/org/scalanative/bindgen/bindings/tests/Utf8procSpec.scala) { #usage-example }
+@@snip [utf8proc](../../../../bindings/utf8proc/src/test/scala/org/scalanative/bindings/tests/Utf8procSpec.scala) { #usage-example }
 
  [utf8proc]: https://juliastrings.github.io/utf8proc/doc/

--- a/project/ParadoxSupport.scala
+++ b/project/ParadoxSupport.scala
@@ -34,8 +34,8 @@ object ParadoxSupport {
     }
 
     def renderBindingDependency(binding: String, printer: Printer): Unit = {
-      val group        = "org.scala-native.bindgen"
-      val artifactName = s"lib$binding"
+      val group        = "org.scala-native.bindings"
+      val artifactName = binding
       val artifactId   = s"${artifactName}_native0.3_${scalaBinaryVersion}"
       val bintrayRepo  = "http://dl.bintray.com/scala-native-bindgen/maven"
 


### PR DESCRIPTION
 - Move the bindings to the org.scala-native.bindings organization.
 - Move binding modules under org.scalanative.bindings dropping the
   per-binding package if only one module is emitted.
 - Drop the "lib" prefix from the binding artifact name.