### PR TITLE
Bring bindgen up-to-date and add some fixes

### DIFF
--- a/bindgen/TypeTranslator.cpp
+++ b/bindgen/TypeTranslator.cpp
@@ -237,8 +237,8 @@ TypeTranslator::addStructDefinition(clang::RecordDecl *record,
         std::shared_ptr<Type> ftype = translate(field->getType());
         uint64_t recordOffsetInBits =
             recordLayout.getFieldOffset(field->getFieldIndex());
-        fields.push_back(std::make_shared<Field>(getFieldName(field),
-                                                 ftype, recordOffsetInBits));
+        fields.push_back(std::make_shared<Field>(getFieldName(field), ftype,
+                                                 recordOffsetInBits));
     }
 
     uint64_t sizeInBits = ctx->getTypeSize(record->getTypeForDecl());

--- a/bindgen/TypeTranslator.cpp
+++ b/bindgen/TypeTranslator.cpp
@@ -8,29 +8,29 @@ TypeTranslator::TypeTranslator(clang::ASTContext *ctx_, IR &ir)
 
     // Native Types
     typeMap["void"] = "Unit";
-    typeMap["bool"] = "native.CBool";
-    typeMap["_Bool"] = "native.CBool";
-    typeMap["char"] = "native.CChar";
-    typeMap["signed char"] = "native.CSignedChar";
-    typeMap["unsigned char"] = "native.CUnsignedChar";
-    typeMap["short"] = "native.CShort";
-    typeMap["unsigned short"] = "native.CUnsignedShort";
-    typeMap["int"] = "native.CInt";
-    typeMap["long int"] = "native.CLongInt";
-    typeMap["unsigned int"] = "native.CUnsignedInt";
-    typeMap["unsigned long int"] = "native.CUnsignedLongInt";
-    typeMap["long"] = "native.CLong";
-    typeMap["unsigned long"] = "native.CUnsignedLong";
-    typeMap["long long"] = "native.CLongLong";
-    typeMap["unsigned long long"] = "native.CUnsignedLongLong";
-    typeMap["size_t"] = "native.CSize";
-    typeMap["ptrdiff_t"] = "native.CPtrDiff";
-    typeMap["wchar_t"] = "native.CWideChar";
-    typeMap["char16_t"] = "native.CChar16";
-    typeMap["char32_t"] = "native.CChar32";
-    typeMap["float"] = "native.CFloat";
-    typeMap["double"] = "native.CDouble";
-    typeMap["long double"] = "native.CDouble";
+    typeMap["bool"] = "unsafe.CBool";
+    typeMap["_Bool"] = "unsafe.CBool";
+    typeMap["char"] = "unsafe.CChar";
+    typeMap["signed char"] = "unsafe.CSignedChar";
+    typeMap["unsigned char"] = "unsafe.CUnsignedChar";
+    typeMap["short"] = "unsafe.CShort";
+    typeMap["unsigned short"] = "unsafe.CUnsignedShort";
+    typeMap["int"] = "unsafe.CInt";
+    typeMap["long int"] = "unsafe.CLongInt";
+    typeMap["unsigned int"] = "unsafe.CUnsignedInt";
+    typeMap["unsigned long int"] = "unsafe.CUnsignedLongInt";
+    typeMap["long"] = "unsafe.CLong";
+    typeMap["unsigned long"] = "unsafe.CUnsignedLong";
+    typeMap["long long"] = "unsafe.CLongLong";
+    typeMap["unsigned long long"] = "unsafe.CUnsignedLongLong";
+    typeMap["size_t"] = "unsafe.CSize";
+    typeMap["ptrdiff_t"] = "unsafe.CPtrDiff";
+    typeMap["wchar_t"] = "unsafe.CWideChar";
+    typeMap["char16_t"] = "unsafe.CChar16";
+    typeMap["char32_t"] = "unsafe.CChar32";
+    typeMap["float"] = "unsafe.CFloat";
+    typeMap["double"] = "unsafe.CDouble";
+    typeMap["long double"] = "unsafe.CDouble";
 }
 
 std::shared_ptr<Type>
@@ -73,8 +73,8 @@ TypeTranslator::translatePointer(const clang::QualType &pte) {
         // Take care of char*
         if (as->getKind() == clang::BuiltinType::Char_S ||
             as->getKind() == clang::BuiltinType::SChar) {
-            // TODO: new PointerType(new PrimitiveType("native.CChar"))
-            return std::make_shared<PrimitiveType>("native.CString");
+            // TODO: new PointerType(new PrimitiveType("unsafe.CChar"))
+            return std::make_shared<PrimitiveType>("unsafe.CString");
         }
     }
 

--- a/bindgen/TypeTranslator.cpp
+++ b/bindgen/TypeTranslator.cpp
@@ -188,13 +188,21 @@ std::shared_ptr<Location> TypeTranslator::getLocation(clang::Decl *decl) {
     return std::make_shared<Location>(path, lineNumber);
 }
 
+std::string getFieldName(const clang::FieldDecl *field) {
+    std::string name = field->getNameAsString();
+    if (name.empty()) {
+        name = "field" + std::to_string(field->getFieldIndex());
+    }
+    return name;
+}
+
 std::shared_ptr<TypeDef>
 TypeTranslator::addUnionDefinition(clang::RecordDecl *record,
                                    std::string name) {
     std::vector<std::shared_ptr<Field>> fields;
 
     for (const clang::FieldDecl *field : record->fields()) {
-        std::string fname = field->getNameAsString();
+        std::string fname = getFieldName(field);
         std::shared_ptr<Type> ftype = translate(field->getType());
 
         fields.push_back(std::make_shared<Field>(fname, ftype));
@@ -229,7 +237,7 @@ TypeTranslator::addStructDefinition(clang::RecordDecl *record,
         std::shared_ptr<Type> ftype = translate(field->getType());
         uint64_t recordOffsetInBits =
             recordLayout.getFieldOffset(field->getFieldIndex());
-        fields.push_back(std::make_shared<Field>(field->getNameAsString(),
+        fields.push_back(std::make_shared<Field>(getFieldName(field),
                                                  ftype, recordOffsetInBits));
     }
 

--- a/bindgen/Utils.h
+++ b/bindgen/Utils.h
@@ -5,23 +5,6 @@
 #include "ir/types/Type.h"
 #include <clang/AST/AST.h>
 
-inline std::string uint64ToScalaNat(uint64_t v, std::string accumulator = "") {
-    if (v == 0)
-        return accumulator;
-
-    auto last_digit = v % 10;
-    auto rest = v / 10;
-
-    if (accumulator.empty()) {
-        return uint64ToScalaNat(rest,
-                                "native.Nat._" + std::to_string(last_digit));
-    } else {
-        return uint64ToScalaNat(rest, "native.Nat.Digit[native.Nat._" +
-                                          std::to_string(last_digit) + ", " +
-                                          accumulator + "]");
-    }
-}
-
 static std::array<std::string, 39> reserved_words = {
     {"abstract",  "case",    "catch",    "class",    "def",     "do",
      "else",      "extends", "false",    "final",    "finally", "for",

--- a/bindgen/defines/DefineFinder.cpp
+++ b/bindgen/defines/DefineFinder.cpp
@@ -48,7 +48,7 @@ void DefineFinder::MacroDefined(const clang::Token &macroNameTok,
                                 stringToken.getLength());
             ir.addLiteralDefine(
                 macroName, "c" + literal,
-                std::make_shared<PrimitiveType>("native.CString"));
+                std::make_shared<PrimitiveType>("unsafe.CString"));
         } else if (tokens->size() == 1 &&
                    (*tokens)[0].getKind() == clang::tok::identifier) {
             // token might be a variable
@@ -126,7 +126,7 @@ void DefineFinder::addNumericConstantDefine(const std::string &macroName,
         if (parser.isLongLong) {
             /* literal has `LL` ending. `long long` is represented as `Long`
              * in Scala Native */
-            type = "native.CLongLong";
+            type = "unsafe.CLongLong";
 
             /* must fit into Scala integer type */
             if (!integerFitsIntoType<long, unsigned long>(parser, positive)) {
@@ -134,7 +134,7 @@ void DefineFinder::addNumericConstantDefine(const std::string &macroName,
             }
         } else if (parser.isLong) {
             /* literal has `L` ending */
-            type = "native.CLong";
+            type = "unsafe.CLong";
 
             /* must fit into Scala integer type */
             if (!integerFitsIntoType<long, unsigned long>(parser, positive)) {
@@ -146,13 +146,13 @@ void DefineFinder::addNumericConstantDefine(const std::string &macroName,
 
         if (!type.empty()) {
             scalaLiteral = getDecimalLiteral(parser);
-            if (type == "native.CLong" || type == "native.CLongLong") {
+            if (type == "unsafe.CLong" || type == "unsafe.CLongLong") {
                 scalaLiteral = scalaLiteral + "L";
             }
         }
     } else if (parser.isFloatingLiteral()) {
         if (fitsIntoDouble(parser)) {
-            type = "native.CDouble";
+            type = "unsafe.CDouble";
             scalaLiteral = getDoubleLiteral(parser);
         }
     }
@@ -172,9 +172,9 @@ DefineFinder::getTypeOfIntegerLiteral(const clang::NumericLiteralParser &parser,
                                       bool positive) {
 
     if (integerFitsIntoType<int, uint>(parser, positive)) {
-        return "native.CInt";
+        return "unsafe.CInt";
     } else if (integerFitsIntoType<long, unsigned long>(parser, positive)) {
-        return "native.CLong";
+        return "unsafe.CLong";
     } else {
         llvm::errs() << "Warning: integer value does not fit into 8 bytes: "
                      << literal << "\n";

--- a/bindgen/ir/Enum.cpp
+++ b/bindgen/ir/Enum.cpp
@@ -1,4 +1,5 @@
 #include "Enum.h"
+#include <sstream>
 
 Enumerator::Enumerator(std::string name, int64_t value)
     : name(std::move(name)), value(value) {}

--- a/bindgen/ir/Enum.cpp
+++ b/bindgen/ir/Enum.cpp
@@ -30,11 +30,11 @@ std::string Enum::getEnumerators() const {
 
 std::string Enum::getTypeCastSuffix() const {
     std::string primitiveType = PrimitiveType::getType();
-    if (primitiveType == "native.CLong") {
+    if (primitiveType == "unsafe.CLong") {
         return "L";
-    } else if (primitiveType == "native.CUnsignedInt") {
+    } else if (primitiveType == "unsafe.CUnsignedInt") {
         return ".toUInt";
-    } else if (primitiveType == "native.CUnsignedLong") {
+    } else if (primitiveType == "unsafe.CUnsignedLong") {
         return "L.toULong";
     }
     return "";

--- a/bindgen/ir/Function.cpp
+++ b/bindgen/ir/Function.cpp
@@ -17,7 +17,7 @@ std::string
 Function::getDefinition(const LocationManager &locationManager) const {
     std::stringstream s;
     if (scalaName != name) {
-        s << "  @native.link(\"" << name << "\")\n";
+        s << "  @unsafe.link(\"" << name << "\")\n";
     }
     s << "  def " << handleReservedWords(scalaName) << "(";
     std::string sep = "";
@@ -29,9 +29,9 @@ Function::getDefinition(const LocationManager &locationManager) const {
     if (isVariadic) {
         /* the C Iso require at least one argument in a variadic function, so
          * the comma is fine */
-        s << ", " << getVarargsParameterName() << ": native.CVararg*";
+        s << ", " << getVarargsParameterName() << ": unsafe.CVararg*";
     }
-    s << "): " << retType->str(locationManager) << " = native.extern\n";
+    s << "): " << retType->str(locationManager) << " = unsafe.extern\n";
     return s.str();
 }
 

--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -1,5 +1,6 @@
 #include "IR.h"
 #include "../Utils.h"
+#include <sstream>
 
 IR::IR(std::string libName, std::string linkName, std::string objectName,
        std::string packageName, const LocationManager &locationManager)

--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -104,14 +104,14 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const IR &ir) {
     }
 
     s << "import scala.scalanative._\n"
-      << "import scala.scalanative.native._\n\n";
+      << "import scala.scalanative.unsafe._\n\n";
 
     if (!ir.functions.empty() || !ir.varDefines.empty() ||
         !ir.variables.empty()) {
         if (!ir.linkName.empty()) {
-            s << "@native.link(\"" << ir.linkName << "\")\n";
+            s << "@unsafe.link(\"" << ir.linkName << "\")\n";
         }
-        s << "@native.extern\n";
+        s << "@unsafe.extern\n";
     }
     s << "object " << handleReservedWords(ir.objectName) << " {\n";
 

--- a/bindgen/ir/IR.h
+++ b/bindgen/ir/IR.h
@@ -89,14 +89,14 @@ class IR {
      *
      * Example:
      * @code
-     * type __int32_t = native.CInt
+     * type __int32_t = unsafe.CInt
      * type __darwin_pid_t = __int32_t
      * type pid_t = __darwin_pid_t
      * @endcode
      *
      * Becomes:
      * @code
-     * type pid_t = native.CInt
+     * type pid_t = unsafe.CInt
      * @endcode
      *
      */

--- a/bindgen/ir/LocationManager.cpp
+++ b/bindgen/ir/LocationManager.cpp
@@ -4,6 +4,7 @@
 #include "Struct.h"
 #include <fstream>
 #include <stdexcept>
+#include <sstream>
 
 LocationManager::LocationManager(std::string mainHeaderPath)
     : mainHeaderPath(std::move(mainHeaderPath)) {}

--- a/bindgen/ir/LocationManager.cpp
+++ b/bindgen/ir/LocationManager.cpp
@@ -3,8 +3,8 @@
 #include "Enum.h"
 #include "Struct.h"
 #include <fstream>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 
 LocationManager::LocationManager(std::string mainHeaderPath)
     : mainHeaderPath(std::move(mainHeaderPath)) {}

--- a/bindgen/ir/Record.cpp
+++ b/bindgen/ir/Record.cpp
@@ -23,11 +23,12 @@ bool Record::usesType(
     if (contains(this, visitedTypes)) {
         return false;
     }
+
     visitedTypes.push_back(shared_from_this());
 
     for (const auto &field : fields) {
-        if (*field->getType() == *type ||
-            field->getType()->usesType(type, stopOnTypeDefs, visitedTypes)) {
+        if (field->getType() && (*field->getType() == *type ||
+            field->getType()->usesType(type, stopOnTypeDefs, visitedTypes))) {
             visitedTypes.pop_back();
             return true;
         }

--- a/bindgen/ir/Record.cpp
+++ b/bindgen/ir/Record.cpp
@@ -27,8 +27,9 @@ bool Record::usesType(
     visitedTypes.push_back(shared_from_this());
 
     for (const auto &field : fields) {
-        if (field->getType() && (*field->getType() == *type ||
-            field->getType()->usesType(type, stopOnTypeDefs, visitedTypes))) {
+        if (field->getType() &&
+            (*field->getType() == *type ||
+             field->getType()->usesType(type, stopOnTypeDefs, visitedTypes))) {
             visitedTypes.pop_back();
             return true;
         }

--- a/bindgen/ir/Struct.cpp
+++ b/bindgen/ir/Struct.cpp
@@ -350,7 +350,7 @@ Struct::getConstructorHelper(const LocationManager &locationManager) const {
 
     /* constructor with no parameters */
     s << "    def apply()(implicit z: unsafe.Zone): unsafe.Ptr[" + type + "]"
-      << " = unsafe.alloc[" + type + "]\n";
+      << " = unsafe.alloc[" + type + "]()\n";
 
     /* constructor that initializes all fields */
     s << "    def apply(";
@@ -361,7 +361,7 @@ Struct::getConstructorHelper(const LocationManager &locationManager) const {
         sep = ", ";
     }
     s << ")(implicit z: unsafe.Zone): unsafe.Ptr[" << type << "] = {\n"
-      << "      val ptr = unsafe.alloc[" << type << "]\n";
+      << "      val ptr = unsafe.alloc[" << type << "]()\n";
     for (const auto &field : fields) {
         std::string name = handleReservedWords(field->getName());
         s << "      ptr." << name << " = " << name << "\n";

--- a/bindgen/ir/Struct.cpp
+++ b/bindgen/ir/Struct.cpp
@@ -34,7 +34,7 @@ Struct::generateHelperClass(const LocationManager &locationManager) const {
     assert(hasHelperMethods());
     std::stringstream s;
     std::string type = replaceChar(getTypeName(), " ", "_");
-    s << "    implicit class " << type << "_ops(val p: native.Ptr[" << type
+    s << "    implicit class " << type << "_ops(val p: unsafe.Ptr[" << type
       << "])"
       << " extends AnyVal {\n";
     if (isRepresentedAsStruct()) {
@@ -89,7 +89,7 @@ std::string Struct::getTypeName() const { return "struct " + name; }
 
 std::string Struct::str(const LocationManager &locationManager) const {
     std::stringstream ss;
-    ss << "native.CStruct" << std::to_string(fields.size()) << "[";
+    ss << "unsafe.CStruct" << std::to_string(fields.size()) << "[";
 
     std::string sep = "";
     for (const auto &field : fields) {
@@ -262,7 +262,7 @@ Struct::getTypeReplacement(std::shared_ptr<const Type> type,
              * value type */
             replacementType = replacementType->replaceType(
                 recordTypeDef,
-                std::make_shared<PrimitiveType>("native.CStruct0"));
+                std::make_shared<PrimitiveType>("unsafe.CStruct0"));
         }
     }
     return replacementType;
@@ -350,8 +350,8 @@ Struct::getConstructorHelper(const LocationManager &locationManager) const {
       << "    import implicits._\n";
 
     /* constructor with no parameters */
-    s << "    def apply()(implicit z: native.Zone): native.Ptr[" + type + "]"
-      << " = native.alloc[" + type + "]\n";
+    s << "    def apply()(implicit z: unsafe.Zone): unsafe.Ptr[" + type + "]"
+      << " = unsafe.alloc[" + type + "]\n";
 
     /* constructor that initializes all fields */
     s << "    def apply(";
@@ -361,8 +361,8 @@ Struct::getConstructorHelper(const LocationManager &locationManager) const {
           << wrapArrayOrRecordInPointer(field->getType())->str(locationManager);
         sep = ", ";
     }
-    s << ")(implicit z: native.Zone): native.Ptr[" << type << "] = {\n"
-      << "      val ptr = native.alloc[" << type << "]\n";
+    s << ")(implicit z: unsafe.Zone): unsafe.Ptr[" << type << "] = {\n"
+      << "      val ptr = unsafe.alloc[" << type << "]\n";
     for (const auto &field : fields) {
         std::string name = handleReservedWords(field->getName());
         s << "      ptr." << name << " = " << name << "\n";

--- a/bindgen/ir/Struct.cpp
+++ b/bindgen/ir/Struct.cpp
@@ -136,7 +136,8 @@ std::string Struct::generateSetterForStructRepresentation(
         /* field type is changed to avoid cyclic types in generated code */
         std::shared_ptr<const Type> typeReplacement = getTypeReplacement(
             field->getType(), structTypesThatShouldBeReplaced);
-        value = value + ".asInstanceOf[" + typeReplacement->str(locationManager) + "]";
+        value = value + ".asInstanceOf[" +
+                typeReplacement->str(locationManager) + "]";
     }
     std::stringstream s;
     s << "      def " << setter << "(value: " + parameterType + "): Unit = p._"
@@ -193,7 +194,8 @@ std::string Struct::generateSetterForArrayRepresentation(
         /* field type is changed to avoid cyclic types in generated code */
         std::shared_ptr<const Type> typeReplacement = getTypeReplacement(
             field->getType(), structTypesThatShouldBeReplaced);
-        value = value + ".asInstanceOf[" + typeReplacement->str(locationManager) + "]";
+        value = value + ".asInstanceOf[" +
+                typeReplacement->str(locationManager) + "]";
     } else if (isArrayOrRecord(field->getType())) {
         value = "!" + value;
     }
@@ -219,8 +221,8 @@ std::string Struct::generateGetterForArrayRepresentation(
     } else {
         methodBody = "p._1";
     }
-    methodBody =
-        methodBody + ".asInstanceOf[" + pointerToFieldType.str(locationManager) + "]";
+    methodBody = methodBody + ".asInstanceOf[" +
+                 pointerToFieldType.str(locationManager) + "]";
 
     if (!isArrayOrRecord(field->getType())) {
         methodBody = "!" + methodBody;

--- a/bindgen/ir/TypeDef.cpp
+++ b/bindgen/ir/TypeDef.cpp
@@ -17,7 +17,7 @@ TypeDef::getDefinition(const LocationManager &locationManager) const {
     if (type) {
         s << type->str(locationManager);
     } else {
-        s << "native.CStruct0 // incomplete type";
+        s << "unsafe.CStruct0 // incomplete type";
     }
     s << "\n";
     return s.str();

--- a/bindgen/ir/Union.cpp
+++ b/bindgen/ir/Union.cpp
@@ -72,7 +72,7 @@ Union::generateGetter(const std::shared_ptr<Field> &field,
     std::string getter = handleReservedWords(field->getName());
     std::string ftype = field->getType()->str(locationManager);
     return "      def " + getter + ": unsafe.Ptr[" + ftype +
-           "] = p.cast[unsafe.Ptr[" + ftype + "]]\n";
+           "] = p.asInstanceOf[unsafe.Ptr[" + ftype + "]]\n";
 }
 
 std::string
@@ -83,8 +83,8 @@ Union::generateSetter(const std::shared_ptr<Field> &field,
     if (isAliasForType<ArrayType>(field->getType().get()) ||
         isAliasForType<Struct>(field->getType().get())) {
         return "      def " + setter + "(value: unsafe.Ptr[" + ftype +
-               "]): Unit = !p.cast[unsafe.Ptr[" + ftype + "]] = !value\n";
+               "]): Unit = !p.asInstanceOf[unsafe.Ptr[" + ftype + "]] = !value\n";
     }
     return "      def " + setter + "(value: " + ftype +
-           "): Unit = !p.cast[unsafe.Ptr[" + ftype + "]] = value\n";
+           "): Unit = !p.asInstanceOf[unsafe.Ptr[" + ftype + "]] = value\n";
 }

--- a/bindgen/ir/Union.cpp
+++ b/bindgen/ir/Union.cpp
@@ -23,7 +23,7 @@ Union::generateHelperClass(const LocationManager &locationManager) const {
     std::stringstream s;
     std::string type = replaceChar(getTypeName(), " ", "_");
     s << "    implicit class " << type << "_pos"
-      << "(val p: native.Ptr[" << type << "]) extends AnyVal {\n";
+      << "(val p: unsafe.Ptr[" << type << "]) extends AnyVal {\n";
     for (const auto &field : fields) {
         if (!field->getName().empty()) {
             s << generateGetter(field, locationManager);
@@ -71,8 +71,8 @@ Union::generateGetter(const std::shared_ptr<Field> &field,
                       const LocationManager &locationManager) const {
     std::string getter = handleReservedWords(field->getName());
     std::string ftype = field->getType()->str(locationManager);
-    return "      def " + getter + ": native.Ptr[" + ftype +
-           "] = p.cast[native.Ptr[" + ftype + "]]\n";
+    return "      def " + getter + ": unsafe.Ptr[" + ftype +
+           "] = p.cast[unsafe.Ptr[" + ftype + "]]\n";
 }
 
 std::string
@@ -82,9 +82,9 @@ Union::generateSetter(const std::shared_ptr<Field> &field,
     std::string ftype = field->getType()->str(locationManager);
     if (isAliasForType<ArrayType>(field->getType().get()) ||
         isAliasForType<Struct>(field->getType().get())) {
-        return "      def " + setter + "(value: native.Ptr[" + ftype +
-               "]): Unit = !p.cast[native.Ptr[" + ftype + "]] = !value\n";
+        return "      def " + setter + "(value: unsafe.Ptr[" + ftype +
+               "]): Unit = !p.cast[unsafe.Ptr[" + ftype + "]] = !value\n";
     }
     return "      def " + setter + "(value: " + ftype +
-           "): Unit = !p.cast[native.Ptr[" + ftype + "]] = value\n";
+           "): Unit = !p.cast[unsafe.Ptr[" + ftype + "]] = value\n";
 }

--- a/bindgen/ir/Union.cpp
+++ b/bindgen/ir/Union.cpp
@@ -83,7 +83,8 @@ Union::generateSetter(const std::shared_ptr<Field> &field,
     if (isAliasForType<ArrayType>(field->getType().get()) ||
         isAliasForType<Struct>(field->getType().get())) {
         return "      def " + setter + "(value: unsafe.Ptr[" + ftype +
-               "]): Unit = !p.asInstanceOf[unsafe.Ptr[" + ftype + "]] = !value\n";
+               "]): Unit = !p.asInstanceOf[unsafe.Ptr[" + ftype +
+               "]] = !value\n";
     }
     return "      def " + setter + "(value: " + ftype +
            "): Unit = !p.asInstanceOf[unsafe.Ptr[" + ftype + "]] = value\n";

--- a/bindgen/ir/VarDefine.cpp
+++ b/bindgen/ir/VarDefine.cpp
@@ -7,7 +7,7 @@ std::string
 VarDefine::getDefinition(const LocationManager &locationManager) const {
     return "  @name(\"" + variable->getName() + "\")\n" + "  val " + name +
            ": " + variable->getType()->str(locationManager) +
-           " = native.extern\n";
+           " = unsafe.extern\n";
 }
 
 bool VarDefine::hasIllegalUsageOfOpaqueType() const {

--- a/bindgen/ir/Variable.cpp
+++ b/bindgen/ir/Variable.cpp
@@ -7,7 +7,7 @@ Variable::Variable(const std::string &name, std::shared_ptr<const Type> type)
 std::string
 Variable::getDefinition(const LocationManager &locationManager) const {
     return "  val " + name + ": " + type->str(locationManager) +
-           " = native.extern\n";
+           " = unsafe.extern\n";
 }
 
 bool Variable::hasIllegalUsageOfOpaqueType() const {

--- a/bindgen/ir/types/ArrayType.cpp
+++ b/bindgen/ir/types/ArrayType.cpp
@@ -7,7 +7,7 @@ ArrayType::ArrayType(std::shared_ptr<const Type> elementsType, uint64_t size)
 
 std::string ArrayType::str(const LocationManager &locationManager) const {
     return "unsafe.CArray[" + elementsType->str(locationManager) + ", " +
-           uint64ToScalaNat(size) + "]";
+           std::to_string(size) + "]";
 }
 
 bool ArrayType::usesType(

--- a/bindgen/ir/types/ArrayType.cpp
+++ b/bindgen/ir/types/ArrayType.cpp
@@ -6,7 +6,7 @@ ArrayType::ArrayType(std::shared_ptr<const Type> elementsType, uint64_t size)
     : size(size), elementsType(std::move(elementsType)) {}
 
 std::string ArrayType::str(const LocationManager &locationManager) const {
-    return "native.CArray[" + elementsType->str(locationManager) + ", " +
+    return "unsafe.CArray[" + elementsType->str(locationManager) + ", " +
            uint64ToScalaNat(size) + "]";
 }
 

--- a/bindgen/ir/types/FunctionPointerType.cpp
+++ b/bindgen/ir/types/FunctionPointerType.cpp
@@ -11,14 +11,14 @@ FunctionPointerType::FunctionPointerType(
 std::string
 FunctionPointerType::str(const LocationManager &locationManager) const {
     std::stringstream ss;
-    ss << "native.CFunctionPtr" << parametersTypes.size() << "[";
+    ss << "unsafe.CFunctionPtr" << parametersTypes.size() << "[";
 
     for (const auto &parameterType : parametersTypes) {
         ss << parameterType->str(locationManager) << ", ";
     }
 
     if (isVariadic) {
-        ss << "native.CVararg, ";
+        ss << "unsafe.CVararg, ";
     }
     ss << returnType->str(locationManager) << "]";
     return ss.str();

--- a/bindgen/ir/types/PointerType.cpp
+++ b/bindgen/ir/types/PointerType.cpp
@@ -5,7 +5,7 @@ PointerType::PointerType(std::shared_ptr<const Type> type)
     : type(std::move(type)) {}
 
 std::string PointerType::str(const LocationManager &locationManager) const {
-    return "native.Ptr[" + type->str(locationManager) + "]";
+    return "unsafe.Ptr[" + type->str(locationManager) + "]";
 }
 
 bool PointerType::usesType(

--- a/bindgen/ir/types/PrimitiveType.h
+++ b/bindgen/ir/types/PrimitiveType.h
@@ -5,7 +5,7 @@
 #include <string>
 
 /**
- * For example native.CInt
+ * For example unsafe.CInt
  */
 class PrimitiveType : virtual public Type {
   public:


### PR DESCRIPTION
- API changes of scala-native (renaming to unsafe, casts, array typing, struct field access, alloc call)
- a segfault in `bindgen/ir/Record.cpp` (for unknown reasons, I have to admit)
- illegal scala code generated for anonymous struct members (as used for unions)